### PR TITLE
Fix exiv2 checker data

### DIFF
--- a/org.kde.koko.json
+++ b/org.kde.koko.json
@@ -29,9 +29,9 @@
                     "sha256": "35a58618ab236a901ca4928b0ad8b31007ebdc0386d904409d825024e45ea6e2",
                     "x-checker-data": {
                         "type": "anitya",
-                        "project-id": 8763,
+                        "project-id": 769,
                         "stable-only": true,
-                        "url-template": "https://download.kde.org/stable/release-service/$version/src/libkexiv2-$version.tar.xz"
+                        "url-template": "https://github.com/Exiv2/exiv2/releases/download/v$version/exiv2-$version-Source.tar.gz"
                     }
                 }
             ]


### PR DESCRIPTION
Fixes the wrong x checker data for exiv2.

https://github.com/flathub/org.kde.koko/pull/5#issuecomment-1071901378